### PR TITLE
chore: Migrating API Gateway and Lambda to dovetail-backups account

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,21 @@ https://drive.google.com/open?id=1tiQXgoRs9gfTeVeEpIu1l0TDDkTfh4dDDm1Eud0zhxQ
 
 # Deploying
 
-make sure you have access to the AWS acount: `kabisa-backups`
+make sure you have access to the AWS acount: `dovetail-backups`
+Note: in case you are using macOS arm64 ARCH in this deployment, please install `serverless` through `brew` using the following:
 
 ```bash
-aws-vault exec kabisa-backups --
+brew install serverless
+```
+some issues were spoted when trying to install `serverless` through `npm` package manager and try to deploy to AWS afterwards using the command:
+
+```bash
+npm install -g serverless
+``` 
+please to proceed in deployment using the following:
+
+```bash
+aws-vault exec dovetail-backups --
 sls deploy
 ```
 
@@ -36,7 +47,7 @@ sls deploy
 
 In order to do backup checks we need access to the specific backup bucket.
 In case the bucket is in a different account you need to grant this access both in the account that owns the bucket as well as the `kabisa-backups` account (for the lambda function) itself.
-The access for the execution role of the lambda function on the `kabisa-backups` account side is managed by serverless.yaml. So there you will need to append the last two lines to the policy section of serverless.yaml:
+The access for the execution role of the lambda function on the `dovetail-backups` account side is managed by serverless.yaml. So there you will need to append the last two lines to the policy section of serverless.yaml:
 
 ```yaml
       Resource:
@@ -52,7 +63,7 @@ This policy needs to be added to the account that hosts the s3 bucket:
     "Sid": "AllowBackupCheck",
     "Effect": "Allow",
     "Principal": {
-        "AWS": "arn:aws:iam::190384451510:role/serverless-backup-analysis-dev-eu-west-1-lambdaRole"
+        "AWS": "arn:aws:iam::158999515498:role/serverless-backup-analysis-dev-eu-west-1-lambdaRole"
     },
     "Action": "s3:ListBucket",
     "Resource": [
@@ -67,7 +78,7 @@ This policy needs to be added to the account that hosts the s3 bucket:
 Requirements:
 
 - `pip install fire` (But the script will notify you if you forgot)
-- `aws-vault exec kabisa-backups` (But the script will notify you if you forgot)
+- `aws-vault exec dovetail-backups` (But the script will notify you if you forgot)
 
 The file `run_local.py` is a [Fire](https://github.com/google/python-fire) script for running this check locally
 Fire helps with nice cli apps. For example if you run `./run_local.py -h` you get this output:

--- a/run_local.py
+++ b/run_local.py
@@ -13,13 +13,13 @@ from backup.server_stats import ServerStats
 
 def main(
     backup_folder: str,
-    bucket_name: str = "kabisa-backup-archive",
+    bucket_name: str = "dovetail-backup-archive",
     file_date_format: Optional[str] = None,
 ):
     try:
         backup_stats = ServerStats(bucket_name, backup_folder, file_date_format)
     except (NoCredentialsError, ClientError) as ex:
-        print(f"Boto error: {ex}\r\n" "Plz run `aws-vault exec kabisa-backups` first")
+        print(f"Boto error: {ex}\r\n" "Plz run `aws-vault exec dovetail-backups` first")
     else:
         print(json.dumps(backup_stats.json))
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,14 +8,8 @@ provider:
       Action:
         - "s3:ListBucket"
       Resource:
-        - "arn:aws:s3:::kabisa-backup"
-        - "arn:aws:s3:::kabisa-backup/*"
-        - "arn:aws:s3:::kabisa-backup-archive"
-        - "arn:aws:s3:::kabisa-backup-archive/*"
         - "arn:aws:s3:::dovetail-backup-archive"
         - "arn:aws:s3:::dovetail-backup-archive/*"
-        - "arn:aws:s3:::kabisa-logdna"
-        - "arn:aws:s3:::kabisa-logdna/*"
 
 plugins:
   - serverless-python-requirements

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,7 +1,7 @@
 service: serverless-backup-analysis
 provider:
   name: aws
-  runtime: python3.6
+  runtime: python3.9
   region: eu-west-1
   iamRoleStatements:
     - Effect: "Allow"


### PR DESCRIPTION
Related to [**`TICKET`**](https://github.com/dovetailworld/devops/issues/11), this PR is to deploy the Serverless Framework in dovetail-backups account which is migrating the API Gateway and the Lambda function from **`kabisa-backups`** account to **`dovetail-backups`** account.